### PR TITLE
feat(duration): Persistent toast

### DIFF
--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -4,6 +4,7 @@ export type ToastConfirm = {
   title: string;
   description?: string
   type: "confirm";
+  duration?: number | "none";
   onConfirm: () => void;
   onCancel?: () => void;
   confirmText?: string;
@@ -14,6 +15,7 @@ export type Toast = {
   title: string;
   description?: string;
   type: ToastType;
+  duration?: number | "none";
 } | ToastConfirm;
 
 export type ToastEventConfirm = Omit<ToastConfirm, "type">;


### PR DESCRIPTION
## Motivation
When you want the user to disclose the toast manually or use confirm you expect an action from user.

## Description
This adds functionality to pass `duration` prop from JS but also you can make the toast persistent through css variable. 
If the value is `Infinity` or <= `0` or `none` the toast will be persistent and only will be disclosed manually.

## TODO or IDEAS

Maybe it is a good idea added a button to disclose when this is set?